### PR TITLE
Path valetudo binary is incorrect

### DIFF
--- a/docs/stepbystep-valetudo-installation.md
+++ b/docs/stepbystep-valetudo-installation.md
@@ -107,7 +107,7 @@ After that, you are able to copy the binary to your conga
 $ ssh root@<robot-ip>
 $> mkdir /mnt/UDISK/valetudo
 $> exit
-$ scp ./build/armv7/valetudo root@<your robot ip>:</mnt/UDISK/valetudo>
+$ scp ./build/armv7/valetudo root@<your robot ip>:</mnt/UDISK/valetudo/valetudo>
 $ scp ./default_config.json root@<your robot ip>:</mnt/UDISK/valetudo/valetudo_config.json>
 ```
 ### Create a script file to export the enviroment variable and run the server at boot in your robot
@@ -142,7 +142,7 @@ shutdown() {
 
 Make the init file executable:
 ```
-$> chmox +x /etc/init.d/valetudo 
+$> chmod +x /etc/init.d/valetudo
 ```
 
 ### Enable Valetudo server at boot and reboot the robot


### PR DESCRIPTION
I noticed that the path to place valetudo was incorrect, and didn't
match the `valetudo_config.json` config file.

Also the command chmox doesn't exist, is a typo I made the last commit.