### PR TITLE
Add  definition for 6090

### DIFF
--- a/docs/sysConfig/6090
+++ b/docs/sysConfig/6090
@@ -1,0 +1,9 @@
+[sysversion_Config]
+hardsysVersion=1.0.2
+sysVersion=S3.5.28
+sysVersionCode=28
+sysProduct=CECOTECCRL30S
+sysSecondProduct=1001
+sysCreateTime=1589524838
+versionType=R
+serverType=r


### PR DESCRIPTION
## Description:
Add definition for Conga model `6090`, so scripts can detect the correct model

## Also:
Rooting this can be done via the ssh method, using `3irobotics` [1](https://github.com/congatudo/stuff/blob/master/docs/rooting-conga.md#user-content-fn-1 - 6f1f8ad594e1b7a2ae68c1d03edefeda) as a password or also using the USB method.

## Tested on:
Only on my own Conga, so if anyone else can try it, it might be helpful.